### PR TITLE
Renamed Taiwan in the countries.json

### DIFF
--- a/src/dev/countries.json
+++ b/src/dev/countries.json
@@ -844,7 +844,7 @@
     "code": "SY"
   },
   {
-    "name": "Taiwan, Province of China",
+    "name": "Taiwan",
     "code": "TW"
   },
   {


### PR DESCRIPTION
Me, having a "Taiwan, Republic of China" identifier card and seeing my country being called as "Taiwan, Province of China" makes me cry. 

Due to the politic issue, maybe just leave it as "Taiwan" will be better, love you 😭👌